### PR TITLE
fix: Do not reset timer when calling `start` after `stop`

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,7 @@ static void resetTimer() {
   }
 
   state.timer_started = false;
+  timer_start_time = 0;
   time_ticker.detach();
   resetScreensaverTimer();
 }
@@ -96,7 +97,12 @@ static void startTimer() {
   if (state.cur_mode >= MODE_TIMER_N && !state.timer_started) {
     state.timer_started = true;
     timer_duration = config.timers[state.cur_mode - 1].duration * 60;
-    timer_start_time = millis();
+
+    if (timer_start_time == 0) {
+      timer_start_time = millis();
+    } else {
+      timer_start_time = millis() - (timer_duration - state.cur_time) * 1000;
+    }
 
     time_ticker.attach(fast_time ? 0.01 : 0.25, []() -> void {
       if (fast_time) {


### PR DESCRIPTION
To differentiate a `stop` from a `reset` we want to keep the `timer_start_time` untouched when doing a `stop` and reset it to `0` when doing a `reset`

Then when doing a `start`, if `timer_start_time` is different than zero then we want to continue the timer instead of restarting it

To do this, we want to compute a new `timer_start_time` that take into account the time that already passed before pausing the timer